### PR TITLE
Fix declaration of qsort_mt and cmp_t

### DIFF
--- a/rling.c
+++ b/rling.c
@@ -349,7 +349,8 @@ extern int optreset;
 #include <xmmintrin.h>
 #endif
 
-extern void qsort_mt();
+typedef int cmp_t(const void *, const void *);
+extern void qsort_mt(void *a, size_t n, size_t es, cmp_t *cmp, int maxthreads, int forkelem);
 
 
 /* After LINELIMIT lines, threads kick in */


### PR DESCRIPTION
Fix build with GCC-15, which is more strict about this kind of things:

```
rling.c: In function ‘main’:
rling.c:2764:28: error: too many arguments to function ‘qsort_mt’; expected 0, have 6
 2764 |             if (!IsSorted) qsort_mt(Sortlist,Line,sizeof(char **),comp1,Maxt,forkelem);
      |                            ^~~~~~~~ ~~~~~~~~
rling.c:352:13: note: declared here
  352 | extern void qsort_mt();
      |             ^~~~~~~~
```